### PR TITLE
Fix: add browser prefixes for compatibility

### DIFF
--- a/blocks/app-for-u/app-for-u.css
+++ b/blocks/app-for-u/app-for-u.css
@@ -12,7 +12,8 @@
   /* flex-wrap: wrap-reverse; */
   /* justify-content: center; */
   max-width: 1024px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   width: 100%;
   margin: auto;
   gap: 60px;
@@ -55,8 +56,12 @@
 }
 
 .app-for-u__links-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   padding: 20.87px 0 0;
 }
 
@@ -81,7 +86,8 @@
   .app-for-u__text-container {
     max-width: 605px;
     padding-right: 42px;
-    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
   }
 
   .app-for-u__title {
@@ -101,7 +107,8 @@
   .app-for-u__text-container {
     max-width: 605px;
     padding-right: 42px;
-    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
   }
 
   .app-for-u__title {
@@ -123,7 +130,8 @@
     margin: 20px 0 0;
     max-width: 605px;
     padding-right: 42px;
-    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
   }
 
   .app-for-u__image {

--- a/blocks/card/card.css
+++ b/blocks/card/card.css
@@ -1,7 +1,8 @@
 .card {
   padding: 20px 10px 60px;
   max-width: 1880px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: auto;
 }
 .card__items {
@@ -40,9 +41,16 @@
 .card__content {
   position: absolute;
   inset: 0;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
   background-color: rgba(0, 0, 0, 0.5);
   height: 100%;
   border-radius: 20px;
@@ -57,16 +65,32 @@
   margin: 0;
 }
 .card__sub-content {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
   padding: 20px;
-  align-items: flex-start;
-  justify-content: center;
+  -webkit-box-align: start;
+      -ms-flex-align: start;
+          align-items: flex-start;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
 }
 .card__paragraphs {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 .card__text {
   color: #fff;
@@ -92,6 +116,8 @@
   padding: 16px;
   background-color: #fff;
   border-radius: 10px;
+  -webkit-transition: color 0.15s ease, background-color 0.15s ease;
+  -o-transition: color 0.15s ease, background-color 0.15s ease;
   transition: color 0.15s ease, background-color 0.15s ease;
   border: none;
   cursor: pointer;
@@ -153,9 +179,16 @@
     padding: 60px 60px;
   }
   .card__sub-content {
-    flex-direction: row;
-    align-items: flex-end;
-    justify-content: space-between;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
+    -webkit-box-align: end;
+        -ms-flex-align: end;
+            align-items: flex-end;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
   }
   .card__text {
     padding: 0;

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -21,11 +21,21 @@
   margin: auto;
   /* end dev */
   padding: 60px 0 72px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: start;
+      -ms-flex-pack: start;
+          justify-content: flex-start;
 }
 
 .carousel__cards {
@@ -33,12 +43,15 @@
   max-width: 100%;
   overflow-x: scroll;
   overflow-y: none;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin: 0;
   margin-bottom: 24px;
   padding: 10px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 
   /* margin-bottom: 16px; */
 }
@@ -52,7 +65,8 @@
   background: #f2f2f2;
   /* margin-bottom: 60px; */
   padding: 20px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 .carousel__card_type_product {
@@ -61,10 +75,17 @@
   padding: 0;
 }
 .carousel__card-heading-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   margin-bottom: 20px;
 }
 
@@ -97,11 +118,18 @@
 }
 
 .carousel__scroll-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   width: 100%;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   padding: 0 16px;
 }
 
@@ -109,6 +137,8 @@
   height: 12px;
   cursor: pointer;
   opacity: 1;
+  -webkit-transition: opacity 0.15s ease;
+  -o-transition: opacity 0.15s ease;
   transition: opacity 0.15s ease;
 }
 

--- a/blocks/divider/divider.css
+++ b/blocks/divider/divider.css
@@ -3,6 +3,7 @@
   height: 1px;
   background-color: #000;
   margin: 0;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   border: none;
 }

--- a/blocks/faq/faq.css
+++ b/blocks/faq/faq.css
@@ -6,8 +6,13 @@
 
 .faq__section {
   margin-bottom: 80px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
 }
 
 .faq__section:last-child {
@@ -15,8 +20,13 @@
 }
 
 .faq__subsection {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
 }
 
 .faq__section-heading {
@@ -30,6 +40,8 @@
 }
 .faq__question-group {
   margin: 0;
+  -webkit-transition: max-height 1s ease, opacity 1.5s ease;
+  -o-transition: max-height 1s ease, opacity 1.5s ease;
   transition: max-height 1s ease, opacity 1.5s ease;
 }
 
@@ -39,14 +51,23 @@
 }
 
 .faq__question-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
   /* DEFAULT */
   margin-bottom: 0px;
   max-height: 0;
   opacity: 0;
   overflow: hidden;
+  -webkit-transition: margin-bottom 0.3s ease-in-out 0.05s, max-height 0.2s ease-in-out 0.05s, opacity 0.1s ease-in-out;
+  -o-transition: margin-bottom 0.3s ease-in-out 0.05s, max-height 0.2s ease-in-out 0.05s, opacity 0.1s ease-in-out;
   transition: margin-bottom 0.3s ease-in-out 0.05s, max-height 0.2s ease-in-out 0.05s, opacity 0.1s ease-in-out;
 }
 
@@ -76,14 +97,24 @@
   margin-bottom: 40px;
   max-height: 500px;
   opacity: 1;
+  -webkit-transition: margin-bottom 0.1s ease-in-out, max-height 0.1s ease-in-out, opacity 0.1s ease-in-out 0.05s;
+  -o-transition: margin-bottom 0.1s ease-in-out, max-height 0.1s ease-in-out, opacity 0.1s ease-in-out 0.05s;
   transition: margin-bottom 0.1s ease-in-out, max-height 0.1s ease-in-out, opacity 0.1s ease-in-out 0.05s;
 }
 
 .faq__question-subcontainer {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
   margin-bottom: 0px;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-transition: all 0.3s ease-out 0.3s;
+  -o-transition: all 0.3s ease-out 0.3s;
   transition: all 0.3s ease-out 0.3s;
   cursor: pointer;
 }
@@ -93,7 +124,8 @@
   font-size: 24px;
   line-height: 28px;
   padding-right: 20px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 .faq__question-toggle {
   max-height: 24px;
@@ -104,6 +136,8 @@
   margin: 0;
   max-height: 0;
   overflow: hidden;
+  -webkit-transition: max-height 0.3s ease;
+  -o-transition: max-height 0.3s ease;
   transition: max-height 0.3s ease;
   font-size: 18px;
   line-height: 28px;
@@ -111,6 +145,8 @@
 
 .faq__question-subcontainer_open {
   margin-bottom: 20px;
+  -webkit-transition: all 0.3s ease;
+  -o-transition: all 0.3s ease;
   transition: all 0.3s ease;
 }
 
@@ -131,9 +167,12 @@
   color: #683d83;
   font-size: 24px;
   line-height: 28px;
+  -webkit-transition: background-color 0.15s ease, color 0.15s ease;
+  -o-transition: background-color 0.15s ease, color 0.15s ease;
   transition: background-color 0.15s ease, color 0.15s ease;
   cursor: pointer;
-  align-self: center;
+  -ms-flex-item-align: center;
+      align-self: center;
 }
 
 .faq__show-button:hover {

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -1,8 +1,17 @@
 .footer {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: start;
+      -ms-flex-pack: start;
+          justify-content: flex-start;
   background: #000;
   color: #fff;
   font-family: 'Roboto Condensed';
@@ -43,6 +52,8 @@
   text-decoration: none;
   color: inherit;
   opacity: 1;
+  -webkit-transition: opacity 0.15s ease;
+  -o-transition: opacity 0.15s ease;
   transition: opacity 0.15s ease;
 }
 
@@ -52,24 +63,35 @@
 
 @media (min-width: 768px) {
   .footer {
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: space-between;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
+    -webkit-box-align: start;
+        -ms-flex-align: start;
+            align-items: flex-start;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
     padding: 40px;
   }
 
   .footer__column {
     text-align: left;
-    flex: 1;
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
     margin-bottom: 0;
   }
 
   .footer__column_content_nav {
-    flex-basis: 48%;
+    -ms-flex-preferred-size: 48%;
+        flex-basis: 48%;
   }
 
   .footer__column_content_contact {
-    flex-basis: 8%;
+    -ms-flex-preferred-size: 8%;
+        flex-basis: 8%;
   }
 }
 
@@ -79,6 +101,7 @@
   }
 
   .footer__column_content_nav {
-    flex-basis: 56%;
+    -ms-flex-preferred-size: 56%;
+        flex-basis: 56%;
   }
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -2,7 +2,8 @@
   padding: 10px;
   position: fixed;
   width: 100%;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   z-index: 5;
 }
 
@@ -13,33 +14,50 @@
 .header__content {
   background-color: transparent;
   border-radius: 10px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
   padding: 16px;
   height: 36px;
   overflow: hidden;
+  -webkit-transition: height 0.3s ease, background-color 0.3s ease;
+  -o-transition: height 0.3s ease, background-color 0.3s ease;
   transition: height 0.3s ease, background-color 0.3s ease;
 }
 
 .header__content_scrolled {
   background-color: #fff;
-  box-shadow: 0 0px 12px rgb(0 0 0 / 30%);
+  -webkit-box-shadow: 0 0px 12px rgb(0 0 0 / 30%);
+          box-shadow: 0 0px 12px rgb(0 0 0 / 30%);
 }
 
 .header__logo-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   margin-bottom: 44px;
 }
 
 .header__logo {
   width: 100px;
   fill: #fff;
+  -webkit-transition: fill 0.15s ease, opacity 0.15s ease;
+  -o-transition: fill 0.15s ease, opacity 0.15s ease;
   transition: fill 0.15s ease, opacity 0.15s ease;
   opacity: 1;
   cursor: pointer;
-  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 1));
+  -webkit-filter: drop-shadow(0 0 2px rgba(0, 0, 0, 1));
+          filter: drop-shadow(0 0 2px rgba(0, 0, 0, 1));
 }
 
 .header__logo:hover {
@@ -47,7 +65,8 @@
 }
 
 .header__logo_scrolled {
-  filter: none;
+  -webkit-filter: none;
+          filter: none;
   fill: #000;
 }
 
@@ -60,6 +79,8 @@
 
 .header__logo-accent {
   fill: #a6a6a6;
+  -webkit-transition: fill 0.15s ease;
+  -o-transition: fill 0.15s ease;
   transition: fill 0.15s ease;
 }
 
@@ -69,12 +90,17 @@
 
 .header__hamburger {
   width: 30px;
+  -webkit-transition: opacity 0.15s ease, -webkit-filter 0.3s ease;
+  transition: opacity 0.15s ease, -webkit-filter 0.3s ease;
+  -o-transition: filter 0.3s ease, opacity 0.15s ease;
   transition: filter 0.3s ease, opacity 0.15s ease;
+  transition: filter 0.3s ease, opacity 0.15s ease, -webkit-filter 0.3s ease;
   cursor: pointer;
 }
 
 .header__hamburger_scrolled {
-  filter: brightness(0%);
+  -webkit-filter: brightness(0%);
+          filter: brightness(0%);
 }
 
 .header__hamburger:hover {
@@ -82,10 +108,19 @@
 }
 
 .header__links {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: start;
+      -ms-flex-pack: start;
+          justify-content: flex-start;
 }
 
 .header__link {
@@ -97,6 +132,8 @@
   line-height: 24px;
   margin: 0;
   margin-bottom: 20px;
+  -webkit-transition: color 0.15s ease;
+  -o-transition: color 0.15s ease;
   transition: color 0.15s ease;
 }
 
@@ -113,12 +150,14 @@
   .header__content_open {
     height: 216px;
     background-color: #fff;
-    box-shadow: 0 0px 12px rgb(0 0 0 / 30%);
+    -webkit-box-shadow: 0 0px 12px rgb(0 0 0 / 30%);
+            box-shadow: 0 0px 12px rgb(0 0 0 / 30%);
   }
 
   .header__logo_opened {
     fill: #000;
-    filter: none;
+    -webkit-filter: none;
+            filter: none;
   }
 
   .header__logo_opened:hover {
@@ -134,11 +173,20 @@
   }
 
   .header__content {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
     padding: 36px;
     height: auto;
+    -webkit-transition: padding 0.3s ease;
+    -o-transition: padding 0.3s ease;
     transition: padding 0.3s ease;
   }
 
@@ -175,14 +223,18 @@
   }
 
   .header__links {
-    flex-direction: row;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
   }
 
   .header__link {
     color: #fff;
     margin-bottom: 0;
     margin-right: 40px;
-    filter: drop-shadow(0 0 2px rgba(0, 0, 0, 1));
+    -webkit-filter: drop-shadow(0 0 2px rgba(0, 0, 0, 1));
+            filter: drop-shadow(0 0 2px rgba(0, 0, 0, 1));
   }
 
   .header__link:last-child {
@@ -191,7 +243,8 @@
 
   .header__link_scrolled {
     color: #000;
-    filter: none;
+    -webkit-filter: none;
+            filter: none;
   }
 
   .header__hamburger {

--- a/blocks/heading/heading.css
+++ b/blocks/heading/heading.css
@@ -12,7 +12,8 @@
 }
 
 .heading_carousel {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   padding: 0 28px;
   text-align: center;
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -15,8 +15,11 @@
   I can fix but I think the black bar across the top looks bad anyways */
   background-size: 325%;
   min-height: 685px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   padding: 116px 20px 0;
 }
@@ -39,8 +42,13 @@
 
   .hero__content {
     background-size: 250%;
-    flex-direction: column;
-    justify-content: center;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
     padding: 40px;
   }
 

--- a/blocks/instagram/instagram.css
+++ b/blocks/instagram/instagram.css
@@ -1,12 +1,20 @@
 .instagram {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
   padding: 60px 20px 80px;
   /* workaround for not so great breakpoints */
   max-width: 500px;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   margin: auto;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 .instagram__image {
@@ -16,9 +24,16 @@
 }
 
 .instagram__text-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: start;
+      -ms-flex-pack: start;
+          justify-content: flex-start;
 }
 
 .instagram__subtitle {
@@ -32,7 +47,8 @@
 .instagram__button-wrapper {
   width: 100%;
   max-width: 400px;
-  align-self: center;
+  -ms-flex-item-align: center;
+      align-self: center;
 }
 
 /* no hover or active styles on button */
@@ -49,7 +65,10 @@
   border-radius: 10px;
   border: 1px solid #683d83;
   cursor: pointer;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  -webkit-transition: color 0.15s ease, background-color 0.15s ease;
+  -o-transition: color 0.15s ease, background-color 0.15s ease;
   transition: color 0.15s ease, background-color 0.15s ease;
 }
 
@@ -58,8 +77,11 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 40px;
-    align-items: center;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
     padding: 80px 40px 100px;
+    grid-template-rows: -webkit-max-content;
     grid-template-rows: max-content;
     /* overriding workaround for not so great breakpoints */
     max-width: none;
@@ -75,7 +97,8 @@
   }
 
   .instagram__button-wrapper {
-    align-self: flex-start;
+    -ms-flex-item-align: start;
+        align-self: flex-start;
   }
 }
 

--- a/blocks/primlancers/primlancers.css
+++ b/blocks/primlancers/primlancers.css
@@ -1,127 +1,134 @@
 .primlancers {
-    padding: 80px 10px 60px;
-    text-align: center;
+  padding: 80px 10px 60px;
+  text-align: center;
 }
 
 .primlancers__title {
-    letter-spacing: -0.01em;
+  letter-spacing: -0.01em;
 }
 
 .primlancers__text {
-    text-align: center;
-    letter-spacing: -0.01em;
-    margin: 40px 0 30px;
-    z-index: 1;
+  text-align: center;
+  letter-spacing: -0.01em;
+  margin: 40px 0 30px;
+  z-index: 1;
 }
 .primlancers__video-container {
-    position: relative;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  position: relative;
+  width: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
 }
 
 .primlancers__video {
-    width: 100%;
-    border-radius: 20px;
-    height: 55.73vw;
-    margin: 0;
+  width: 100%;
+  border-radius: 20px;
+  height: 55.73vw;
+  margin: 0;
 }
 .overlay {
-    width: 100%;
-    height: 55.73vw;
-    border-radius: 20px;
-    background-image: url(../../images/primlancersVideoPreview.png);
-    background-repeat: no-repeat;
-    background-position: center;
-    z-index: 0;
-    position: absolute;
-    background-size: 101.66vw 63.73vw;
-    margin: 0;
+  width: 100%;
+  height: 55.73vw;
+  border-radius: 20px;
+  background-image: url(../../images/primlancersVideoPreview.png);
+  background-repeat: no-repeat;
+  background-position: center;
+  z-index: 0;
+  position: absolute;
+  background-size: 101.66vw 63.73vw;
+  margin: 0;
 }
 
 .overlay:before {
-    content: "";
-    height: 55.73vw;
-    width: 100%;
-    border-radius: 20px;
-    background: rgba(0, 0, 0, 0.5);
-    position: absolute;
-    top: 0;
-    left: 0;
+  content: '';
+  height: 55.73vw;
+  width: 100%;
+  border-radius: 20px;
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .primlancers__video-button {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 0;
-    height: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
 }
 
 .primlancers__video-button:before {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 74px;
-    height: 74px;
-    margin: -40px 0 0 -40px;
-    border: 5px solid #fff;
-    border-radius: 100%;
-    -webkit-transition: border-color 300ms;
-    -moz-transition: border-color 300ms;
-    transition: border-color 300ms;
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 74px;
+  height: 74px;
+  margin: -40px 0 0 -40px;
+  border: 5px solid #fff;
+  border-radius: 100%;
+  -webkit-transition: border-color 300ms;
+  -o-transition: border-color 300ms;
+  transition: border-color 300ms;
 }
 .primlancers__video-button:after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 0;
-    height: 0;
-    margin: -20px 0 0 -10px;
-    border-left: 30px solid #fff;
-    border-top: 22.5px solid transparent;
-    border-bottom: 22.5px solid transparent;
-    -webkit-transition: border-color 300ms;
-    -moz-transition: border-color 300ms;
-    transition: border-color 300ms;
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  margin: -20px 0 0 -10px;
+  border-left: 30px solid #fff;
+  border-top: 22.5px solid transparent;
+  border-bottom: 22.5px solid transparent;
+  -webkit-transition: border-color 300ms;
+  -o-transition: border-color 300ms;
+  transition: border-color 300ms;
 }
 
 .video_active {
-    display: none;
-    opacity: 0;
+  display: none;
+  opacity: 0;
 }
 
 .primlancers__video-button:hover:before,
 .primlancers__video-button:focus:before {
-    border-color: #683d83;
-    cursor: pointer;
+  border-color: #683d83;
+  cursor: pointer;
 }
 
 .primlancers__video-button:hover:after,
 .primlancers__video-button:focus:after {
-    border-left-color: #683d83;
-    cursor: pointer;
+  border-left-color: #683d83;
+  cursor: pointer;
 }
 
 .primlancers__book-button {
-    max-width: 335px;
-    width: 100%;
-    height: auto;
-    padding: 16px 0;
-    font-family: "Roboto Condensed", Arial, Helvetica, sans-serif;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 24px;
-    line-height: 28px;
-    text-transform: uppercase;
-    color: #ffffff;
-    background-color: #683d83;
-    border-radius: 10px;
-    border: none;
-    cursor: pointer;
+  max-width: 335px;
+  width: 100%;
+  height: auto;
+  padding: 16px 0;
+  font-family: 'Roboto Condensed', Arial, Helvetica, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 24px;
+  line-height: 28px;
+  text-transform: uppercase;
+  color: #ffffff;
+  background-color: #683d83;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
 }
 
 @media (min-width: 480px) {
@@ -131,49 +138,49 @@
 }
 
 @media (min-width: 768px) {
-    .primlancers {
-        padding: 100px 40px 80px;
-    }
+  .primlancers {
+    padding: 100px 40px 80px;
+  }
 
-    .primlancers__video {
-        max-width: 860px;
-        max-height: 449px;
-    }
+  .primlancers__video {
+    max-width: 860px;
+    max-height: 449px;
+  }
 
-    .overlay {
-        max-width: 860px;
-        height: 100%;
-        background-size: auto;
-        max-height: 451px;
-    }
-    .overlay:before {
-        max-width: 860px;
-        max-height: 449px;
-        height: 100%;
-    }
+  .overlay {
+    max-width: 860px;
+    height: 100%;
+    background-size: auto;
+    max-height: 451px;
+  }
+  .overlay:before {
+    max-width: 860px;
+    max-height: 449px;
+    height: 100%;
+  }
 }
 
 @media (min-width: 1024px) {
-    .primlancers {
-        padding: 100px 88px 80px;
-    }
+  .primlancers {
+    padding: 100px 88px 80px;
+  }
 
-    .primlancers__title {
-        font-size: 50px;
-        line-height: 59px;
-    }
+  .primlancers__title {
+    font-size: 50px;
+    line-height: 59px;
+  }
 
-    .primlancers__text {
-        font-size: 38px;
-        line-height: 45px;
-        color: #ffffff;
-        position: relative;
-        top: -188px;
-    }
+  .primlancers__text {
+    font-size: 38px;
+    line-height: 45px;
+    color: #ffffff;
+    position: relative;
+    top: -188px;
+  }
 
-    .primlancers__book-button {
-        margin-top: -60px;
-    }
+  .primlancers__book-button {
+    margin-top: -60px;
+  }
 }
 
 @media (min-width: 1440px) {

--- a/blocks/providers/providers.css
+++ b/blocks/providers/providers.css
@@ -2,6 +2,7 @@
   padding: 60px 10px 0;
   margin: auto;
   max-width: 1880px;
+  -webkit-box-sizing: border-box;
   box-sizing: border-box;
 }
 .providers__heading {
@@ -30,9 +31,18 @@
   height: 100%;
   width: 100%;
   background-color: rgba(0, 0, 0, 0.5);
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
   border-radius: 20px;
 }
@@ -55,6 +65,8 @@
   padding: 16px 50px;
   background-color: #fff;
   border-radius: 10px;
+  -webkit-transition: color 0.15s ease, background-color 0.15s ease;
+  -o-transition: color 0.15s ease, background-color 0.15s ease;
   transition: color 0.15s ease, background-color 0.15s ease;
   border: none;
   cursor: pointer;
@@ -75,9 +87,7 @@
   .providers {
     padding: 60px 40px 0;
   }
-  .providers__heading {
-    /* margin: 100px 0 60px; */
-  }
+
   .provider__card {
     margin-bottom: 0;
   }

--- a/blocks/treat-yourself/treat-yourself.css
+++ b/blocks/treat-yourself/treat-yourself.css
@@ -2,7 +2,8 @@
   padding: 0 10px 60px;
   max-width: 1880px;
   margin: auto;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 .treat-yourself__card-area {
   display: grid;
@@ -17,25 +18,38 @@
   overflow: hidden;
   text-transform: uppercase;
   border-radius: 20px;
-  text-overflow: ellipsis;
+  -o-text-overflow: ellipsis;
+     text-overflow: ellipsis;
 }
 .treat-yourself__card-image {
   width: 100%;
   height: 100%;
+  -webkit-transition: all 0.3s ease;
+  -o-transition: all 0.3s ease;
   transition: all 0.3s ease;
 }
 .treat-yourself__card:hover .treat-yourself__card-image {
-  transform: scale(1.05);
+  -webkit-transform: scale(1.05);
+      -ms-transform: scale(1.05);
+          transform: scale(1.05);
 }
 .treat-yourself__text-container {
   position: absolute;
   inset: 0;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #ffff;
   border-radius: 20px;
   background-color: rgba(0, 0, 0, 0.5);
+  -webkit-transition: background-color 0.3s ease;
+  -o-transition: background-color 0.3s ease;
   transition: background-color 0.3s ease;
 }
 .treat-yourself__text-container:hover {


### PR DESCRIPTION
I won't merge this myself as it's a little bigger of a change. I used the VSCode autoprefixing plugin with the attached settings: Last four versions of browsers, IE 9 or greater, with at least >5% usage. 

<img width="174" alt="Screen Shot 2021-06-27 at 3 13 17 PM" src="https://user-images.githubusercontent.com/74033573/123556661-73842280-d75a-11eb-8623-2c3582033d6e.png">
